### PR TITLE
Remove Python 2.6 support (#37)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,7 +4,6 @@
 enable=all
 disable=
     bad-whitespace,
-    bare-except,
     fixme,
     invalid-name,
     missing-docstring,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Sedsed has a homemade custom testing solution, comprised of multiple shell scrip
 
 ## CI
 
-For every new commit, Travis CI runs the code linter and all the tests. The tests are checked in multiple Python versions, from 2.6 to 3.6. See [.travis.yml](.travis.yml).
+For every new commit, Travis CI runs the code linter and all the tests. The tests are checked in multiple Python versions, from 2.7 to 3.6. See [.travis.yml](.travis.yml).
 
 ## New version release checklist
 

--- a/sedsed.py
+++ b/sedsed.py
@@ -154,14 +154,16 @@ def write_file(file_path, lines):
 
 
 def system_command(cmd):  # Returns a (#exit_code, program_output[]) tuple
-    # TODO don't use popen()
+    ret = None
     output = []
+
     fd = os.popen(cmd)
     for line in fd.readlines():
         output.append(line.rstrip())  # stripping \s*\n
     ret = fd.close()
     if ret:
         ret = ret / 256  # 16bit number
+
     return ret, output
 
 
@@ -284,14 +286,10 @@ def validate_script_syntax(script_text):
     tmpfile2 = tempfile.mktemp()
     write_file(tmpfile1, script_text)
     write_file(tmpfile2, '')
-    try:
-        # sed -f sed_script empty_file
-        ret, msg = system_command("%s -f '%s' '%s'" % (
-            sedbin, tmpfile1, tmpfile2))
-    except:
-        # popen(), used in system_command, is broken on Win9x machines
-        # https://docs.python.org/2.6/faq/windows.html
-        ret = None
+
+    # sed -f sed_script empty_file
+    ret, msg = system_command("%s -f '%s' '%s'" % (
+        sedbin, tmpfile1, tmpfile2))
     os.remove(tmpfile1)
     os.remove(tmpfile2)
 


### PR DESCRIPTION
It seems this was the only point in the code where 2.6 matters.
It was also the last offending code for the bare-except pylint check.