### PR TITLE
Use "code formatter", not "indenter and HTMLizer" as description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sedsed
 
-Debugger, indenter and HTMLizer for sed scripts, by Aurelio Jargas.
+Debugger and code formatter for sed scripts, by Aurelio Jargas.
 
 Website: https://aurelio.net/projects/sedsed/
 

--- a/sedsed.py
+++ b/sedsed.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# sedsed - Debugger, indenter and HTMLizer for sed scripts
+# sedsed - Debugger and code formatter for sed scripts
 # Since 27 November 2001, by Aurelio Jargas
 
 __version__ = '1.2-dev'
@@ -464,8 +464,8 @@ html_data = {
 
     'footer': """
 <font color="%s"><b>### colorized by <a \
-href="%s">sedsed</a>, a SED script \
-debugger/indenter/tokenizer/HTMLizer</b></font>\n
+href="%s">sedsed</a>, a debugger and code formatter \
+for sed scripts</b></font>\n
 </pre></body></html>\
 """ % (html_colors['comment'], myhome)
 }

--- a/test/html/=.sed.html
+++ b/test/html/=.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>=</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/a.sed.html
+++ b/test/html/a.sed.html
@@ -12,6 +12,6 @@
 <font color="#ffff00"><b>a</b></font><font color="#00ff00"><b>\
 </b></font>a;b;c
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/address.gnu.sed.html
+++ b/test/html/address.gnu.sed.html
@@ -322,6 +322,6 @@
 <font color="#00ffff"><b># Remove the original line</b></font>
 <font color="#ffff00"><b>d</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/address.sed.html
+++ b/test/html/address.sed.html
@@ -226,6 +226,6 @@
 <font color="#00ffff"><b># Remove the original line</b></font>
 <font color="#ffff00"><b>d</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/anagrams.gnu.sed.html
+++ b/test/html/anagrams.gnu.sed.html
@@ -133,6 +133,6 @@
     <font color="#ffff00"><b>t</b></font> <a href="#loop">loop</a>
 <font color="#ff6060"><b>}</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/b.sed.html
+++ b/test/html/b.sed.html
@@ -10,6 +10,6 @@
 <font color="#ffff00"><b>b</b></font> 
 <font color="#ffff00"><b>d</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/bf2c.sed.html
+++ b/test/html/bf2c.sed.html
@@ -27,6 +27,6 @@
 <font color="#00ffff"><b># ++++&lt;-]&gt;&gt;[&lt;.&gt;&gt;+&lt;-]&gt;[-&lt;+&gt;]&lt;+&lt;&lt;+++++[-&gt;++++++&lt;]&gt;.--.&lt;++++[&gt;-----</b></font>
 <font color="#00ffff"><b># --&lt;-]&gt;.++++++++.&lt;+++[&gt;++++++&lt;-]&gt;.++++.[-]++++++++++.[-]&lt;&lt;-]&lt;]</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/c.sed.html
+++ b/test/html/c.sed.html
@@ -12,6 +12,6 @@
 <font color="#ffff00"><b>c</b></font><font color="#00ff00"><b>\
 </b></font>a;b;c
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/cal.sed.html
+++ b/test/html/cal.sed.html
@@ -103,6 +103,6 @@
     <font color="#ffff00"><b>b</b></font> <a href="#line">line</a>
 <font color="#ff6060"><b>}</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/comment.gnu.sed.html
+++ b/test/html/comment.gnu.sed.html
@@ -15,6 +15,6 @@
 
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#ff6060"><b>/</b></font><font color="#ff6060"><b>/</b></font>;# script end
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/comment.sed.html
+++ b/test/html/comment.sed.html
@@ -17,6 +17,6 @@
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#ff6060"><b>/</b></font><font color="#ff6060"><b>/</b></font>
 <font color="#00ffff"><b># script end</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/config.sed.html
+++ b/test/html/config.sed.html
@@ -495,6 +495,6 @@
     <font color="#ffff00"><b>p</b></font>
 <font color="#ff6060"><b>}</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/d.sed.html
+++ b/test/html/d.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>d</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/d^.sed.html
+++ b/test/html/d^.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>D</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/dc.sed.html
+++ b/test/html/dc.sed.html
@@ -329,6 +329,6 @@
 
 <font color="#00ffff"><b>#  END OF GSU dc.sed</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/expand.sed.html
+++ b/test/html/expand.sed.html
@@ -37,6 +37,6 @@
 <font color="#00ffff"><b>#</b></font>
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>[^	]*	</b></font><font color="#ff6060"><b>/</b></font><font color="#ff6060"><b>/</b></font><font color="#00ff00"><b>g</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/fmt.sed.html
+++ b/test/html/fmt.sed.html
@@ -25,6 +25,6 @@
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>^.*\n</b></font><font color="#ff6060"><b>/</b></font><font color="#ff6060"><b>/</b></font>
 <font color="#ffff00"><b>b</b></font> <a href="#a">a</a>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/fullcmd.gnu.sed.html
+++ b/test/html/fullcmd.gnu.sed.html
@@ -7,6 +7,6 @@
 <font color="#00ffff"><b># GNU sed extras: /address/I and s///i</b></font>
 <font color="#ff6060"><b>\</b></font><font color="#ff6060"><b>,</b></font><font color="#8080ff"><b>addr1</b></font><font color="#ff6060"><b>,</b></font><font color="#ff6060"><b>I</b></font>,<font color="#ff6060"><b>/</b></font><font color="#ff6060"><b>/</b></font> <font color="#ff6060"><b>!</b></font><font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>a</b></font><font color="#ff6060"><b>/</b></font>.<font color="#ff6060"><b>/</b></font><font color="#00ff00"><b>igpw</b></font> <font color="#ff00ff"><b>w.out1</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/fullcmd.sed.html
+++ b/test/html/fullcmd.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ff6060"><b>\</b></font><font color="#ff6060"><b>,</b></font><font color="#8080ff"><b>addr1</b></font><font color="#ff6060"><b>,</b></font>,<font color="#ff6060"><b>/</b></font><font color="#ff6060"><b>/</b></font> <font color="#ff6060"><b>!</b></font><font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>a</b></font><font color="#ff6060"><b>/</b></font>.<font color="#ff6060"><b>/</b></font><font color="#00ff00"><b>gpw</b></font> <font color="#ff00ff"><b>w.out1</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/g.sed.html
+++ b/test/html/g.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>g</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/g^.sed.html
+++ b/test/html/g^.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>G</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/gotchas.sed.html
+++ b/test/html/gotchas.sed.html
@@ -9,6 +9,6 @@
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>Ione</b></font><font color="#ff6060"><b>/</b></font>FAIL<font color="#ff6060"><b>/</b></font>
 
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/h.sed.html
+++ b/test/html/h.sed.html
@@ -7,6 +7,6 @@
 <font color="#ffff00"><b>h</b></font>
 <font color="#ffff00"><b>G</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/h^.sed.html
+++ b/test/html/h^.sed.html
@@ -7,6 +7,6 @@
 <font color="#ffff00"><b>H</b></font>
 <font color="#ffff00"><b>G</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/html_uc.gnu.sed.html
+++ b/test/html/html_uc.gnu.sed.html
@@ -74,6 +74,6 @@
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>J</b></font><font color="#ff6060"><b>/</b></font>j<font color="#ff6060"><b>/</b></font>
 <font color="#ffff00"><b>x</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/i.sed.html
+++ b/test/html/i.sed.html
@@ -12,6 +12,6 @@
 <font color="#ffff00"><b>i</b></font><font color="#00ff00"><b>\
 </b></font>a;b;c
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/impossible.gnu.sed.html
+++ b/test/html/impossible.gnu.sed.html
@@ -38,6 +38,6 @@
 <font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>^\n</b></font><font color="#ff6060"><b>/</b></font> <font color="#ffff00"><b>P</b></font>
 <font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>.</b></font><font color="#ff6060"><b>/</b></font> <font color="#ffff00"><b>b</b></font> <a href="#loop">loop</a>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/incr_num.sed.html
+++ b/test/html/incr_num.sed.html
@@ -52,6 +52,6 @@
 <font color="#00ffff"><b>#</b></font>
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>_</b></font><font color="#ff6060"><b>/</b></font>0<font color="#ff6060"><b>/</b></font><font color="#00ff00"><b>g</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/l.sed.html
+++ b/test/html/l.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>l</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/n.sed.html
+++ b/test/html/n.sed.html
@@ -7,6 +7,6 @@
 <font color="#ffff00"><b>n</b></font>
 <font color="#ffff00"><b>d</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/n^.sed.html
+++ b/test/html/n^.sed.html
@@ -7,6 +7,6 @@
 <font color="#ffff00"><b>N</b></font>
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>\n</b></font><font color="#ff6060"><b>/</b></font><font color="#ff6060"><b>/</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/p.sed.html
+++ b/test/html/p.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>p</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/p^.sed.html
+++ b/test/html/p^.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>P</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/q.sed.html
+++ b/test/html/q.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#8080ff"><b>3</b></font> <font color="#ffff00"><b>q</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/r.sed.html
+++ b/test/html/r.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>r</b></font> <font color="#ff00ff"><b>r.sed</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/revlines.sed.html
+++ b/test/html/revlines.sed.html
@@ -15,6 +15,6 @@
 <font color="#ffff00"><b>h</b></font>
 <font color="#8080ff"><b>$</b></font> <font color="#ffff00"><b>p</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/s-delimiter.sed.html
+++ b/test/html/s-delimiter.sed.html
@@ -19,6 +19,6 @@
 <font color="#00ffff"><b>#1</b></font>
 <font color="#00ffff"><b>#</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/s-flags.gnu.sed.html
+++ b/test/html/s-flags.gnu.sed.html
@@ -21,6 +21,6 @@
 
 <font color="#00ffff"><b># http://www.gnu.org/software/sed/manual/sed.html -- 3.5 The s Command</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/s-flags.sed.html
+++ b/test/html/s-flags.sed.html
@@ -11,6 +11,6 @@
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>w</b></font><font color="#ff6060"><b>/</b></font>W<font color="#ff6060"><b>/</b></font><font color="#00ff00"><b>gp</b></font>
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>.</b></font><font color="#ff6060"><b>/</b></font><font color="#00ff00"><b>&amp;</b></font><font color="#ff6060"><b>/</b></font><font color="#00ff00"><b>w</b></font> <font color="#ff00ff"><b>w.out1</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/s.sed.html
+++ b/test/html/s.sed.html
@@ -10,6 +10,6 @@
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>$</b></font><font color="#ff6060"><b>/</b></font>$<font color="#ff6060"><b>/</b></font>
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>\/</b></font><font color="#ff6060"><b>/</b></font>\/<font color="#ff6060"><b>/</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/sedcheck.sed.html
+++ b/test/html/sedcheck.sed.html
@@ -314,6 +314,6 @@
 
 
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/sodelnum.gnu.sed.html
+++ b/test/html/sodelnum.gnu.sed.html
@@ -69,6 +69,6 @@
 
 <font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>.</b></font><font color="#ff6060"><b>/</b></font> <font color="#ffff00"><b>b</b></font> <a href="#number">number</a>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/sokoban.sed.html
+++ b/test/html/sokoban.sed.html
@@ -2308,6 +2308,6 @@
 
 <font color="#00ffff"><b># The End ;(</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/sort.gnu.sed.html
+++ b/test/html/sort.gnu.sed.html
@@ -130,6 +130,6 @@
 </b></font><font color="#ff6060"><b>/</b></font><font color="#00ff00"><b>g</b></font>
 
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/t.sed.html
+++ b/test/html/t.sed.html
@@ -12,6 +12,6 @@
 <font color="#ffff00"><b>t</b></font> 
 <font color="#ffff00"><b>d</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/tex2xml.gnu.sed.html
+++ b/test/html/tex2xml.gnu.sed.html
@@ -86,6 +86,6 @@
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>,</b></font><font color="#8080ff"><b>&amp;obrace;</b></font><font color="#ff6060"><b>,</b></font>{<font color="#ff6060"><b>,</b></font><font color="#00ff00"><b>g</b></font>
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>,</b></font><font color="#8080ff"><b>&amp;cbrace;</b></font><font color="#ff6060"><b>,</b></font>}<font color="#ff6060"><b>,</b></font><font color="#00ff00"><b>g</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/tolower.sed.html
+++ b/test/html/tolower.sed.html
@@ -37,6 +37,6 @@
 <font color="#00ffff"><b># and print it</b></font>
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>^\<font color="#ff00ff"><b>(</b></font>.*\/\)\<font color="#ff00ff"><b>(</b></font>.*\)\n\<font color="#ff00ff"><b>(</b></font>.*\)$</b></font><font color="#ff6060"><b>/</b></font>mv <font color="#00ff00"><b>\1</b></font><font color="#00ff00"><b>\2</b></font> <font color="#00ff00"><b>\1</b></font><font color="#00ff00"><b>\3</b></font><font color="#ff6060"><b>/</b></font><font color="#00ff00"><b>p</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/ttest1.sed.html
+++ b/test/html/ttest1.sed.html
@@ -13,6 +13,6 @@
 <font color="#00ffff"><b>#echo a | sed -&gt; b </b></font>
 <font color="#00ffff"><b>#echo b | sed -&gt; (blank)</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/ttest2.sed.html
+++ b/test/html/ttest2.sed.html
@@ -19,6 +19,6 @@
 <font color="#ff00ff"><b>:</b></font><font color="#ff00ff"><b><a name="t_ok_2">t_ok_2</a></b></font>
 <font color="#ffff00"><b>s</b></font><font color="#ff6060"><b>/</b></font><font color="#8080ff"><b>.*</b></font><font color="#ff6060"><b>/</b></font>reached t2!<font color="#ff6060"><b>/</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/w.sed.html
+++ b/test/html/w.sed.html
@@ -7,6 +7,6 @@
 <font color="#ffff00"><b>w</b></font> <font color="#ff00ff"><b>w.out1</b></font>
 <font color="#ffff00"><b>w</b></font> <font color="#ff00ff"><b>w.out2</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/x.sed.html
+++ b/test/html/x.sed.html
@@ -6,6 +6,6 @@
 <pre>
 <font color="#ffff00"><b>x</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>

--- a/test/html/y.sed.html
+++ b/test/html/y.sed.html
@@ -20,6 +20,6 @@
 <font color="#00ffff"><b>#1</b></font>
 <font color="#00ffff"><b>#</b></font>
 
-<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a SED script debugger/indenter/tokenizer/HTMLizer</b></font>
+<font color="#00ffff"><b>### colorized by <a href="https://aurelio.net/projects/sedsed/">sedsed</a>, a debugger and code formatter for sed scripts</b></font>
 
 </pre></body></html>


### PR DESCRIPTION
Indenter is not accurate, since it also formats commands and adresses.

HTMLizer is a descriptive term, but not widespread.

Code formatter is well known and refers to both actions.