### PR TITLE
Fix tests broken by semver switch

### DIFF
--- a/test/command_line.md
+++ b/test/command_line.md
@@ -135,9 +135,9 @@ $
 
 ```
 $ sedsed --version | tr -s 0-9 9 | sed 's/-dev//'
-sedsed v9.9
+sedsed v9.9.9
 $ sedsed -V        | tr -s 0-9 9 | sed 's/-dev//'
-sedsed v9.9
+sedsed v9.9.9
 $
 ```
 


### PR DESCRIPTION
Sedsed switched to using semantic versioning, but some tests were still
expecting the old N.N version.