### PR TITLE
Add Makefile for common tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,24 +18,14 @@ install:
     pip install --quiet -r requirements-dev.txt;;
     esac
 
-  # Download clitest
-  - curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
-  - chmod +x clitest
-  - mv clitest ~/bin
-
   # Install sedsed itself and its dependency (sedparse)
   - pip install -e .
 
 script:
   - case $TRAVIS_PYTHON_VERSION in 3.6)
-    pylint ./*.py test/*.py;;
+    make check;;
     esac
-  - case $TRAVIS_PYTHON_VERSION in 3.6)
-    black --check ./*.py test/*.py;;
-    esac
-  - find . -name run | xargs shellcheck -x
-  - clitest test/command_line.md
-  - ./test/run
+  - make test
 
 ### Environment
 # Ubuntu 14.04.5 LTS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,21 +32,24 @@ The sedsed code is checked by pylint and formatted by [black](https://github.com
 
 Black is used with the default settings (no command line options) and the pylint configuration file is in the root of this repository.
 
+To install the tools in the development environment (venv):
+
+    pip install -r requirements-dev.txt
+
 Just run them over the Python files:
 
-    pylint *.py test/*.py
-    black  *.py test/*.py
+    make check
 
 
 ## Testing
 
-Sedsed has a homemade custom testing solution, comprised of multiple shell scripts and test files. You can read more about it at [test/README.md](test/README.md). To run all the tests, just do:
-
-    ./test/run
+Sedsed has a homemade custom testing solution, comprised of multiple shell scripts and test files. You can read more about it at [test/README.md](test/README.md).
 
 There are also some extra tests for full command lines, using a Markdown file to describe the commands and their expected outputs, and [clitest](https://github.com/aureliojargas/clitest) runs and checks them.
 
-    clitest test/command_line.md
+To run all the tests, just do:
+
+    make test
 
 
 ## Automation (CI)
@@ -107,6 +110,6 @@ To upload the package to TestPyPI index (good for testing) and install it locall
     twine upload --repository-url https://test.pypi.org/legacy/ dist/*
     pip install -i https://test.pypi.org/simple/ sedsed
 
-To upload the package to the offical PyPI index:
+To upload the package to the official PyPI index:
 
     twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: black check clean pylint sedparse shellcheck test
+
+# Main targets
+
+check: black pylint shellcheck
+
+test: clitest sedparse
+	bash ./clitest test/command_line.md
+	./test/run
+
+clean:
+	rm -f clitest
+
+# Secondary targets
+
+black:
+	black --check --diff --quiet ./*.py test/*.py
+
+pylint: sedparse
+	pylint ./*.py test/*.py
+
+shellcheck:
+	find . -name run | xargs shellcheck -x
+
+# Dependencies
+
+clitest:
+	curl --location --remote-name --silent \
+	https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
+
+sedparse:
+	@command -v sedparse || \
+	pip install `grep -o 'sedparse[ =<>.0-9*]*' setup.py`


### PR DESCRIPTION
Instead of having those commands only in the Travis CI configuration
file, now they are easier to execute as make targets.

Documentation was also updated to reflect those changes.

Fixes #76